### PR TITLE
Jsdeps support

### DIFF
--- a/app/playscalajs/jsdeps.scala.html
+++ b/app/playscalajs/jsdeps.scala.html
@@ -1,0 +1,10 @@
+@(projectName: String, assetsPath: String = "/assets", resourcesPath: String = "/public")
+
+@import play.api.Play.resource
+@import play.api.Play.current
+
+@defining(s"${projectName.toLowerCase}-jsdeps.js") { jsdeps =>
+  @if(resource(s"$resourcesPath/$jsdeps").isDefined) {
+<script src="@{s"$assetsPath/$jsdeps"}" type="text/javascript"></script>
+  }
+}

--- a/app/playscalajs/launcher.scala.html
+++ b/app/playscalajs/launcher.scala.html
@@ -1,3 +1,3 @@
-@(basePath: String, projectName: String)
+@(projectName: String, assetsPath: String = "/assets")
 
-<script src="@{s"$basePath/${projectName.toLowerCase}-launcher.js"}" type="text/javascript"></script>
+<script src="@{s"$assetsPath/${projectName.toLowerCase}-launcher.js"}" type="text/javascript"></script>

--- a/app/playscalajs/scripts.scala.html
+++ b/app/playscalajs/scripts.scala.html
@@ -1,4 +1,5 @@
-@(basePath: String, projectName: String)
+@(projectName: String, assetsPath: String = "/assets", resourcesPath: String = "/public")
 
-@selectScript(basePath, projectName)
-@launcher(basePath, projectName)
+@selectScript(projectName, assetsPath)
+@launcher(projectName, assetsPath)
+@jsdeps(projectName, assetsPath, resourcesPath)

--- a/app/playscalajs/selectScript.scala.html
+++ b/app/playscalajs/selectScript.scala.html
@@ -1,9 +1,9 @@
-@(basePath: String, projectName: String)
+@(projectName: String, assetsPath: String = "/assets")
 
 @import play.api.Play
 
 @if(Play.isProd(Play.current)) {
-<script src="@{s"$basePath/${projectName.toLowerCase}-opt.js"}" type="text/javascript"></script>
+<script src="@{s"$assetsPath/${projectName.toLowerCase}-opt.js"}" type="text/javascript"></script>
 } else {
-<script src="@{s"$basePath/${projectName.toLowerCase}-fastopt.js"}" type="text/javascript"></script>
+<script src="@{s"$assetsPath/${projectName.toLowerCase}-fastopt.js"}" type="text/javascript"></script>
 }

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import bintray.Keys._
 
 name := "play-scalajs-scripts"
 
-version := "0.1.0"
+version := "0.2.0-SNAPSHOT"
 
 organization := "com.vmunier"
 


### PR DESCRIPTION
- Adds support for jsdeps:
`jsdeps.scala.html` checks that the `<projectName>-jsdeps.js` resource exists to add a script tag to include the js file. 
So if the user set `skip in packageJSDependencies := false`, the `-jsdeps.js` file exists and the script tag is added to the html. The script tag is not added  when the `-jsdeps.js` resource does not exist to avoid requesting the server for a resource which does not exist and would result in a 404.

- Usage and order of the arguments in the different scripts have changed. `assetsPath` and `resourcesPath` have default values.
Call `@playscalajs.html.scripts("exampleClient")` where you previously called `@playscalajs.html.scripts("/assets", projectName = "exampleClient")`