### PR TITLE
Load jsdeps first.

### DIFF
--- a/app/playscalajs/scripts.scala.html
+++ b/app/playscalajs/scripts.scala.html
@@ -1,5 +1,5 @@
 @(projectName: String, assetsPath: String = "/assets", resourcesPath: String = "/public")
 
+@jsdeps(projectName, assetsPath, resourcesPath)
 @selectScript(projectName, assetsPath)
 @launcher(projectName, assetsPath)
-@jsdeps(projectName, assetsPath, resourcesPath)


### PR DESCRIPTION
In some cases, the dependencies have to be loaded first because the main script depends on some global initialization made by the dependencies.